### PR TITLE
Add Serializable Lucene and Database Manager Providers

### DIFF
--- a/src/main/java/com/divroll/datafactory/database/DatabaseManagerProvider.java
+++ b/src/main/java/com/divroll/datafactory/database/DatabaseManagerProvider.java
@@ -1,0 +1,25 @@
+/*
+ * Divroll, Platform for Hosting Static Sites
+ * Copyright 2024, Divroll, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.divroll.datafactory.database;
+
+/**
+ * The DatabaseManagerProvider interface provides a method to retrieve an instance of the DatabaseManager.
+ * Implementing classes must provide an implementation of the getDatabaseManager method.
+ */
+public interface DatabaseManagerProvider {
+    DatabaseManager getDatabaseManager();
+}

--- a/src/main/java/com/divroll/datafactory/database/SerializableDatabaseManagerProvider.java
+++ b/src/main/java/com/divroll/datafactory/database/SerializableDatabaseManagerProvider.java
@@ -1,0 +1,36 @@
+/*
+ * Divroll, Platform for Hosting Static Sites
+ * Copyright 2024, Divroll, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.divroll.datafactory.database;
+
+import com.divroll.datafactory.database.impl.DatabaseManagerImpl;
+
+import java.io.Serializable;
+
+/**
+ * The SerializableDatabaseManagerProvider class implements the DatabaseManagerProvider interface
+ * and provides an implementation for the getDatabaseManager method by returning an instance of
+ * the DatabaseManagerImpl class.
+ *
+ * This class also implements the Serializable interface to allow objects of this class to be serialized
+ * and deserialized.
+ */
+public class SerializableDatabaseManagerProvider implements DatabaseManagerProvider, Serializable {
+    @Override
+    public DatabaseManager getDatabaseManager() {
+        return DatabaseManagerImpl.getInstance();
+    }
+}

--- a/src/main/java/com/divroll/datafactory/indexers/LuceneIndexerProvider.java
+++ b/src/main/java/com/divroll/datafactory/indexers/LuceneIndexerProvider.java
@@ -1,0 +1,24 @@
+/*
+ * Divroll, Platform for Hosting Static Sites
+ * Copyright 2024, Divroll, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.divroll.datafactory.indexers;
+
+/**
+ * The LuceneIndexerProvider interface provides a method to retrieve a LuceneIndexer instance.
+ */
+public interface LuceneIndexerProvider {
+    LuceneIndexer getLuceneIndexer();
+}

--- a/src/main/java/com/divroll/datafactory/indexers/SerializableLuceneIndexerProvider.java
+++ b/src/main/java/com/divroll/datafactory/indexers/SerializableLuceneIndexerProvider.java
@@ -1,0 +1,33 @@
+/*
+ * Divroll, Platform for Hosting Static Sites
+ * Copyright 2024, Divroll, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.divroll.datafactory.indexers;
+
+import com.divroll.datafactory.indexers.impl.LuceneIndexerImpl;
+
+import java.io.Serializable;
+
+/**
+ * The SerializableLuceneIndexerProvider class is an implementation of the LuceneIndexerProvider interface.
+ * It provides a method to retrieve a singleton instance of LuceneIndexer using LuceneIndexerImpl.getInstance().
+ * This class is Serializable, allowing the LuceneIndexerProvider instance to be serialized and deserialized.
+ */
+public class SerializableLuceneIndexerProvider implements LuceneIndexerProvider, Serializable {
+    @Override
+    public LuceneIndexer getLuceneIndexer() {
+        return LuceneIndexerImpl.getInstance();
+    }
+}


### PR DESCRIPTION
Refactored code to include the addition of LuceneIndexerProvider and DatabaseManagerProvider which are serializable. These changes include updating related classes and constructors where these new providers are being utilized. This update is the fix for Issue #2 