### PR TITLE
Refactor DataFactoryEntity and related classes to simpler names

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,13 @@ Thus, it follows the concept of _all-or-nothing_.
 ##### Save Operation
 
 ```java
-DataFactoryEntity dataFactoryEntity = new DataFactoryEntityBuilder()
+DataFactoryEntity entity = new DataFactoryEntityBuilder()
     .environment(PROD_ENVIRONMENT)
     .entityType("Room")
     .putPropertyMap("address", "Room 123, 456 Street, 789 Avenue")
     .build();
 
-dataFactoryEntity = entityStore.saveEntity(dataFactoryEntity).get();
+entity = entityStore.saveEntity(entity).get();
 ```
 
 #### Actions
@@ -79,7 +79,7 @@ but custom actions can also be used. An example implementation can be found [her
 ```java
 entityStore.saveEntity(new DataFactoryEntityBuilder()
     .environment(PROD_ENVIRONMENT)
-    .entityId(dataFactoryEntity.entityId())
+    .entityId(entity.entityId())
     .addActions(new IncrementLikesAction(100))
     .build());
 ```
@@ -92,9 +92,9 @@ off-the-shelf which can be found [here](https://sourcegraph.com/github.com/divro
 however it also possible to create custom conditions as such:
 
 ```java
-dataFactoryEntity = entityStore.saveEntity(new DataFactoryEntityBuilder()
+entity = entityStore.saveEntity(new DataFactoryEntityBuilder()
     .environment(PROD_ENVIRONMENT)
-    .entityId(dataFactoryEntity.entityId())
+    .entityId(entity.entityId())
     .addConditions(new HasBeenLikedThisWeekCondition())
     .addActions(new IncrementLikesAction(100))
     .build()).get();

--- a/src/main/java/com/divroll/datafactory/Marshaller.java
+++ b/src/main/java/com/divroll/datafactory/Marshaller.java
@@ -19,10 +19,10 @@
  */
 package com.divroll.datafactory;
 
-import com.divroll.datafactory.builders.DataFactoryBlob;
-import com.divroll.datafactory.builders.DataFactoryBlobBuilder;
-import com.divroll.datafactory.builders.DataFactoryEntity;
-import com.divroll.datafactory.builders.DataFactoryEntityBuilder;
+import com.divroll.datafactory.builders.Blob;
+import com.divroll.datafactory.builders.Entity;
+import com.divroll.datafactory.builders.BlobBuilder;
+import com.divroll.datafactory.builders.EntityBuilder;
 import com.divroll.datafactory.builders.queries.BlobQuery;
 import com.divroll.datafactory.builders.queries.LinkQuery;
 import com.divroll.datafactory.properties.EmbeddedArrayIterable;
@@ -31,7 +31,6 @@ import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;
 import com.healthmarketscience.rmiio.SimpleRemoteInputStream;
-import jetbrains.exodus.entitystore.Entity;
 import jetbrains.exodus.entitystore.EntityIterable;
 import jetbrains.exodus.entitystore.StoreTransaction;
 import org.jetbrains.annotations.NotNull;
@@ -42,7 +41,7 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * The Marshaller class is used to build a DataFactoryEntity for remote transmission.
+ * The Marshaller class is used to build a Entity for remote transmission.
  * It provides methods to set the entity, link queries, and blob queries, and a build
  */
 public class Marshaller {
@@ -55,7 +54,7 @@ public class Marshaller {
    *
    * Private field representing the entity.
    */
-  private Entity entity;
+  private jetbrains.exodus.entitystore.Entity entity;
   /**
    * Represents a list of LinkQuery objects.
    */
@@ -71,7 +70,7 @@ public class Marshaller {
    * @param entity the entity to add
    * @return the updated marshaller
    */
-  public Marshaller with(@NotNull final Entity entity) {
+  public Marshaller with(@NotNull final jetbrains.exodus.entitystore.Entity entity) {
     if (this.entity != null) {
       throw new IllegalArgumentException("Entity is already set");
     }
@@ -109,13 +108,13 @@ public class Marshaller {
   }
 
   /**
-   * Builds a {@linkplain Entity} into a {@linkplain DataFactoryEntity} for remote transmission.
+   * Builds a {@linkplain jetbrains.exodus.entitystore.Entity} into a {@linkplain Entity} for remote transmission.
    * This method should be called within a database {@linkplain StoreTransaction}.
    *
    * @return {@code entity}
    */
-  public DataFactoryEntity build() {
-    final DataFactoryEntityBuilder builder = new DataFactoryEntityBuilder();
+  public Entity build() {
+    final EntityBuilder builder = new EntityBuilder();
 
     entity.getPropertyNames().forEach(propertyName -> {
       Comparable propertyValue = entity.getProperty(propertyName);
@@ -132,8 +131,8 @@ public class Marshaller {
       }
     });
 
-    List<DataFactoryBlob> blobs = new ArrayList<>();
-    Multimap<String, DataFactoryEntity> links = ArrayListMultimap.create();
+    List<Blob> blobs = new ArrayList<>();
+    Multimap<String, Entity> links = ArrayListMultimap.create();
 
     if (linkQueries == null) {
       linkQueries = new ArrayList<>();
@@ -165,7 +164,7 @@ public class Marshaller {
         if (blobQuery.blobName().equals(blobName) && blobQuery.include()) {
           InputStream blobStream = entity.getBlob(blobName);
           Long blobSize = entity.getBlobSize(blobName);
-          blobs.add(new DataFactoryBlobBuilder()
+          blobs.add(new BlobBuilder()
               .blobName(blobName)
               .blobStream(new SimpleRemoteInputStream(blobStream))
               .blobSize(blobSize)

--- a/src/main/java/com/divroll/datafactory/actions/LinkNewEntityAction.java
+++ b/src/main/java/com/divroll/datafactory/actions/LinkNewEntityAction.java
@@ -19,7 +19,7 @@
  */
 package com.divroll.datafactory.actions;
 
-import com.divroll.datafactory.builders.DataFactoryEntity;
+import com.divroll.datafactory.builders.Entity;
 import java.io.Serializable;
 import org.immutables.value.Value;
 
@@ -40,7 +40,7 @@ public interface LinkNewEntityAction extends EntityAction, Serializable {
    *
    * @return The new entity to be linked.
    */
-  DataFactoryEntity newEntity();
+  Entity newEntity();
 
   /**
    * Returns whether the link is set or not.

--- a/src/main/java/com/divroll/datafactory/actions/package-info.java
+++ b/src/main/java/com/divroll/datafactory/actions/package-info.java
@@ -1,5 +1,5 @@
 /**
  * This package contains the defined actions for
- * {@linkplain com.divroll.datafactory.builders.DataFactoryEntity} operations.
+ * {@linkplain com.divroll.datafactory.builders.Entity} operations.
  */
 package com.divroll.datafactory.actions;

--- a/src/main/java/com/divroll/datafactory/builders/Blob.java
+++ b/src/main/java/com/divroll/datafactory/builders/Blob.java
@@ -26,7 +26,7 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @Value.Style(visibility = Value.Style.ImplementationVisibility.PRIVATE)
-public interface DataFactoryBlob extends Serializable {
+public interface Blob extends Serializable {
   /**
    * Retrieves the name of the blob.
    *
@@ -65,9 +65,9 @@ public interface DataFactoryBlob extends Serializable {
   }
 
   /**
-   * Retrieves the count of a DataFactoryBlob.
+   * Retrieves the count of a Blob.
    *
-   * @return The count of the DataFactoryBlob, or null if the count is unknown.
+   * @return The count of the Blob, or null if the count is unknown.
    */
   @Nullable
   Long count();

--- a/src/main/java/com/divroll/datafactory/builders/Entities.java
+++ b/src/main/java/com/divroll/datafactory/builders/Entities.java
@@ -30,15 +30,15 @@ import org.immutables.value.Value;
  */
 @Value.Immutable
 @Value.Style(visibility = Value.Style.ImplementationVisibility.PRIVATE)
-public interface DataFactoryEntities extends Serializable {
+public interface Entities extends Serializable {
   /**
    *
-   * Returns a list of DataFactoryEntity objects.
+   * Returns a list of Entity objects.
    *
-   * @return the list of DataFactoryEntity objects
+   * @return the list of Entity objects
    */
   @Value.Default
-  default List<DataFactoryEntity> entities() {
+  default List<Entity> entities() {
     return new ArrayList<>();
   }
   /**
@@ -49,7 +49,7 @@ public interface DataFactoryEntities extends Serializable {
   @Nullable
   Integer offset();
   /**
-   * Returns the maximum value for the 'max' attribute in the DataFactoryEntities class.
+   * Returns the maximum value for the 'max' attribute in the Entities class.
    *
    * @return the maximum value for the 'max' attribute, or null if not set
    */

--- a/src/main/java/com/divroll/datafactory/builders/Entity.java
+++ b/src/main/java/com/divroll/datafactory/builders/Entity.java
@@ -35,23 +35,23 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * DataFactoryEntity represents an entity in the data factory system.
+ * Entity represents an entity in the data factory system.
  * It contains information such as the entity type, ID, namespace, property map, blobs,
  * links, and more. This is an immutable interface, which means the attributes cannot be modified
- * once set. Use the DataFactoryEntityBuilder to construct instances of this interface.
+ * once set. Use the EntityBuilder to construct instances of this interface.
  */
 @Value.Immutable
 @Value.Style(visibility = Value.Style.ImplementationVisibility.PRIVATE)
-public interface DataFactoryEntity extends Serializable {
+public interface Entity extends Serializable {
 
   /**
-   * Checks if the DataFactoryEntity has at least either an Entity Type or ID.
+   * Checks if the Entity has at least either an Entity Type or ID.
    *
-   * @return The DataFactoryEntity object.
+   * @return The Entity object.
    * @throws IllegalStateException if both the Entity Type and ID are null or empty.
    */
   @Value.Check
-  default DataFactoryEntity check() {
+  default Entity check() {
     Preconditions.checkState(
         !((entityType() == null
                 || entityType().isEmpty()) && (entityId() == null
@@ -72,7 +72,7 @@ public interface DataFactoryEntity extends Serializable {
   }
 
   /**
-   * Retrieves the entity type of a DataFactoryEntity.
+   * Retrieves the entity type of a Entity.
    *
    * @return The entity type as a String. Returns null if no entity type is set.
    */
@@ -80,7 +80,7 @@ public interface DataFactoryEntity extends Serializable {
   String entityType();
 
   /**
-   * Retrieves the namespace of a DataFactoryEntity.
+   * Retrieves the namespace of a Entity.
    *
    * @return The namespace as a String. Returns null if no namespace is set.
    */
@@ -96,7 +96,7 @@ public interface DataFactoryEntity extends Serializable {
   String entityId();
 
   /**
-   * Returns the property map of a DataFactoryEntity.
+   * Returns the property map of a Entity.
    *
    * @return The property map as a {@code Map<String, Comparable>} object.
    * Returns a new empty {@code LinkedHashMap} if no properties are set.
@@ -108,32 +108,32 @@ public interface DataFactoryEntity extends Serializable {
   }
 
   /**
-   * Retrieves the list of blobs associated with the DataFactoryEntity.
+   * Retrieves the list of blobs associated with the Entity.
    *
-   * @return The list of DataFactoryBlob objects. Returns an empty list if no blobs are associated
+   * @return The list of Blob objects. Returns an empty list if no blobs are associated
    * with the entity. The returned list is nullable.
    */
   @Nullable
   @Value.Default
-  default List<DataFactoryBlob> blobs() {
+  default List<Blob> blobs() {
     return new ArrayList<>();
   }
 
   /**
-   * Retrieves the links associated with the DataFactoryEntity.
+   * Retrieves the links associated with the Entity.
    *
-   * @return The Multimap of links, where the key is a String and the value is a DataFactoryEntity.
+   * @return The Multimap of links, where the key is a String and the value is a Entity.
    * Returns an empty Multimap if no links are associated with the entity.
    * The returned Multimap is nullable.
    */
   @Nullable
   @Value.Default
-  default Multimap<String, DataFactoryEntity> links() {
+  default Multimap<String, Entity> links() {
     return ArrayListMultimap.create();
   }
 
   /**
-   * Retrieves the array of blob names associated with the DataFactoryEntity.
+   * Retrieves the array of blob names associated with the Entity.
    *
    * @return The array of blob names as a String array.
    *         The array is nullable and returns null if no blob names are associated with the entity.
@@ -145,7 +145,7 @@ public interface DataFactoryEntity extends Serializable {
   }
 
   /**
-   * Retrieves the array of link names associated with the DataFactoryEntity.
+   * Retrieves the array of link names associated with the Entity.
    *
    * @return The array of link names as a String array.
    *         The array is nullable and returns null if no link names are associated with the entity.
@@ -157,7 +157,7 @@ public interface DataFactoryEntity extends Serializable {
   }
 
   /**
-   * Retrieves the list of actions performed on the DataFactoryEntity.
+   * Retrieves the list of actions performed on the Entity.
    *
    * @return The list of EntityAction objects as a List.
    *         The list is nullable and returns a new empty ArrayList if no actions
@@ -170,7 +170,7 @@ public interface DataFactoryEntity extends Serializable {
   }
 
   /**
-   * Retrieves the list of transaction filters applied to the DataFactoryEntity.
+   * Retrieves the list of transaction filters applied to the Entity.
    *
    * @return  The list of TransactionFilter objects as a List.
    *          The list is nullable and returns a new empty ArrayList if no filters
@@ -183,7 +183,7 @@ public interface DataFactoryEntity extends Serializable {
   }
 
   /**
-   * Retrieves the list of conditions applied to the DataFactoryEntity.
+   * Retrieves the list of conditions applied to the Entity.
    *
    * @return The list of EntityConditions as a List of EntityCondition objects.
    *         This method returns a new empty ArrayList if no conditions are applied.

--- a/src/main/java/com/divroll/datafactory/builders/EntityType.java
+++ b/src/main/java/com/divroll/datafactory/builders/EntityType.java
@@ -19,37 +19,18 @@
  */
 package com.divroll.datafactory.builders;
 
-import java.util.ArrayList;
-import java.util.List;
-import javax.annotation.Nullable;
 import org.immutables.value.Value;
-
 /**
- * DataFactoryEntityTypes is an interface that represents a collection of Entity Types in a
- * Data Factory. It provides methods to retrieve the list of entity types and the count of
- * entities.
+ * EntityType is an interface that represents an entity type in a Data Factory.
+ * It provides methods to retrieve the name of the entity type.
  */
 @Value.Immutable
 @Value.Style(visibility = Value.Style.ImplementationVisibility.PRIVATE)
-public interface DataFactoryEntityTypes {
+public interface EntityType {
   /**
-   * Returns the list of entity types.
+   * Returns the name of the entity type.
    *
-   * @return the list of entity types as a List<DataFactoryEntityType>.
+   * @return the name of the entity type as a String.
    */
-  @Value.Default
-  default List<DataFactoryEntityType> entityTypes() {
-    return new ArrayList<>();
-  }
-
-  /**
-   * Retrieves the count of entities.
-   *
-   * @return the count of entities as a Long, or null if not available
-   */
-  @Nullable
-  @Value.Default
-  default Long entityCount() {
-    return -1L;
-  }
+  String entityTypeName();
 }

--- a/src/main/java/com/divroll/datafactory/builders/EntityTypes.java
+++ b/src/main/java/com/divroll/datafactory/builders/EntityTypes.java
@@ -19,18 +19,37 @@
  */
 package com.divroll.datafactory.builders;
 
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nullable;
 import org.immutables.value.Value;
+
 /**
- * DataFactoryEntityType is an interface that represents an entity type in a Data Factory.
- * It provides methods to retrieve the name of the entity type.
+ * EntityTypes is an interface that represents a collection of Entity Types in a
+ * Data Factory. It provides methods to retrieve the list of entity types and the count of
+ * entities.
  */
 @Value.Immutable
 @Value.Style(visibility = Value.Style.ImplementationVisibility.PRIVATE)
-public interface DataFactoryEntityType {
+public interface EntityTypes {
   /**
-   * Returns the name of the entity type.
+   * Returns the list of entity types.
    *
-   * @return the name of the entity type as a String.
+   * @return the list of entity types as a List<EntityType>.
    */
-  String entityTypeName();
+  @Value.Default
+  default List<EntityType> entityTypes() {
+    return new ArrayList<>();
+  }
+
+  /**
+   * Retrieves the count of entities.
+   *
+   * @return the count of entities as a Long, or null if not available
+   */
+  @Nullable
+  @Value.Default
+  default Long entityCount() {
+    return -1L;
+  }
 }

--- a/src/main/java/com/divroll/datafactory/builders/Property.java
+++ b/src/main/java/com/divroll/datafactory/builders/Property.java
@@ -27,14 +27,14 @@ import javax.annotation.Nullable;
 import org.immutables.value.Value;
 
 /**
- * DataFactoryProperty is an interface that represents a property for the DataFactory class.
+ * Property is an interface that represents a property for the DataFactory class.
  * It extends the Serializable interface.
  */
 @Value.Immutable
 @Value.Style(visibility = Value.Style.ImplementationVisibility.PRIVATE)
-public interface DataFactoryProperty extends Serializable {
+public interface Property extends Serializable {
   /**
-   * Retrieves the environment for the {@link DataFactoryProperty} instance.
+   * Retrieves the environment for the {@link Property} instance.
    *
    * @return The environment value.
    */
@@ -44,14 +44,14 @@ public interface DataFactoryProperty extends Serializable {
   }
 
   /**
-   * Returns the entityType of the DataFactoryProperty instance.
+   * Returns the entityType of the Property instance.
    *
    * @return The entityType value.
    */
   String entityType();
 
   /**
-   * Retrieves the name space for the DataFactoryProperty instance.
+   * Retrieves the name space for the Property instance.
    *
    * @return The name space value, or null if not set.
    */
@@ -59,7 +59,7 @@ public interface DataFactoryProperty extends Serializable {
   String nameSpace();
 
   /**
-   * Retrieves the property actions for the DataFactoryProperty instance.
+   * Retrieves the property actions for the Property instance.
    *
    * @return The list of EntityPropertyAction objects.
    */

--- a/src/main/java/com/divroll/datafactory/builders/queries/BlobQuery.java
+++ b/src/main/java/com/divroll/datafactory/builders/queries/BlobQuery.java
@@ -23,7 +23,7 @@ import java.io.Serializable;
 import org.immutables.value.Value;
 
 /**
- * Represents a query to rename a blob.
+ * Represents a blob query.
  */
 @Value.Immutable
 @Value.Style(visibility = Value.Style.ImplementationVisibility.PRIVATE)

--- a/src/main/java/com/divroll/datafactory/builders/queries/EntityQuery.java
+++ b/src/main/java/com/divroll/datafactory/builders/queries/EntityQuery.java
@@ -20,6 +20,7 @@
 package com.divroll.datafactory.builders.queries;
 
 import com.divroll.datafactory.Constants;
+import com.divroll.datafactory.builders.Entity;
 import com.divroll.datafactory.builders.TransactionFilter;
 import com.divroll.datafactory.conditions.EntityCondition;
 import java.io.Serializable;
@@ -29,7 +30,7 @@ import javax.annotation.Nullable;
 import org.immutables.value.Value;
 
 /**
- * Represents a query to retrieve an entity.
+ * Represents a query to an entity.
  */
 @Value.Immutable
 @Value.Style(visibility = Value.Style.ImplementationVisibility.PRIVATE)
@@ -75,7 +76,7 @@ public interface EntityQuery extends Serializable {
   /**
    * Indicates the {@code linkNames} to use in the query.
    *
-   * @return names of the links of {@linkplain com.divroll.datafactory.builders.DataFactoryEntity}
+   * @return names of the links of {@linkplain Entity}
    * to query
    */
   @Nullable
@@ -87,7 +88,7 @@ public interface EntityQuery extends Serializable {
   /**
    * Indicates the {@code blobNames} to use in the query.
    *
-   * @return names of the blobs of {@linkplain com.divroll.datafactory.builders.DataFactoryEntity}
+   * @return names of the blobs of {@linkplain Entity}
    * to query
    */
   @Nullable

--- a/src/main/java/com/divroll/datafactory/builders/queries/EntityTypeQuery.java
+++ b/src/main/java/com/divroll/datafactory/builders/queries/EntityTypeQuery.java
@@ -24,6 +24,9 @@ import java.io.Serializable;
 import javax.annotation.Nullable;
 import org.immutables.value.Value;
 
+/**
+ * Represents a query to retrieve an entity type.
+ */
 @Value.Immutable
 @Value.Style(visibility = Value.Style.ImplementationVisibility.PRIVATE)
 public interface EntityTypeQuery extends Serializable {

--- a/src/main/java/com/divroll/datafactory/builders/queries/LinkQuery.java
+++ b/src/main/java/com/divroll/datafactory/builders/queries/LinkQuery.java
@@ -21,6 +21,8 @@ package com.divroll.datafactory.builders.queries;
 
 import java.io.Serializable;
 import javax.annotation.Nullable;
+
+import com.divroll.datafactory.builders.Entity;
 import org.immutables.value.Value;
 
 /**
@@ -38,7 +40,7 @@ public interface LinkQuery extends Serializable {
 
   /**
    * Indicates to include the
-   * {@linkplain com.divroll.datafactory.builders.DataFactoryEntity} body in the query response.
+   * {@linkplain Entity} body in the query response.
    *
    * @return  True if the linked entity body will be included in the query response,
    *          false otherwise

--- a/src/main/java/com/divroll/datafactory/builders/queries/PropertyQuery.java
+++ b/src/main/java/com/divroll/datafactory/builders/queries/PropertyQuery.java
@@ -22,9 +22,9 @@ package com.divroll.datafactory.builders.queries;
 import java.io.Serializable;
 import javax.annotation.Nullable;
 import org.immutables.value.Value;
-
+import com.divroll.datafactory.builders.Entity;
 /**
- * Represents a query to retrieve a property.
+ * Represents a query to retrieve a {@linkplain Entity} property.
  */
 @Value.Immutable
 @Value.Style(visibility = Value.Style.ImplementationVisibility.PRIVATE)

--- a/src/main/java/com/divroll/datafactory/repositories/EntityStore.java
+++ b/src/main/java/com/divroll/datafactory/repositories/EntityStore.java
@@ -19,10 +19,10 @@
  */
 package com.divroll.datafactory.repositories;
 
-import com.divroll.datafactory.builders.DataFactoryEntities;
-import com.divroll.datafactory.builders.DataFactoryEntity;
-import com.divroll.datafactory.builders.DataFactoryEntityTypes;
-import com.divroll.datafactory.builders.DataFactoryProperty;
+import com.divroll.datafactory.builders.Entities;
+import com.divroll.datafactory.builders.Entity;
+import com.divroll.datafactory.builders.EntityTypes;
+import com.divroll.datafactory.builders.Property;
 import com.divroll.datafactory.builders.queries.EntityQuery;
 import com.divroll.datafactory.builders.queries.EntityTypeQuery;
 import com.divroll.datafactory.exceptions.DataFactoryException;
@@ -46,7 +46,7 @@ public interface EntityStore extends Remote {
    * @throws NotBoundException
    * @throws RemoteException
    */
-  Option<DataFactoryEntity> saveEntity(@NotNull DataFactoryEntity entity)
+  Option<Entity> saveEntity(@NotNull Entity entity)
       throws DataFactoryException, DataFactoryException, NotBoundException, RemoteException;
 
   /**
@@ -58,7 +58,7 @@ public interface EntityStore extends Remote {
    * @throws NotBoundException
    * @throws RemoteException
    */
-  Option<DataFactoryEntities> saveEntities(@NotNull DataFactoryEntity[] entities)
+  Option<Entities> saveEntities(@NotNull Entity[] entities)
       throws DataFactoryException, NotBoundException, RemoteException;
 
   /**
@@ -70,7 +70,7 @@ public interface EntityStore extends Remote {
    * @throws NotBoundException
    * @throws RemoteException
    */
-  Option<DataFactoryEntity> getEntity(@NotNull EntityQuery query)
+  Option<Entity> getEntity(@NotNull EntityQuery query)
       throws DataFactoryException, NotBoundException, RemoteException;
 
   /**
@@ -82,7 +82,7 @@ public interface EntityStore extends Remote {
    * @throws NotBoundException
    * @throws RemoteException
    */
-  Option<DataFactoryEntities> getEntities(@NotNull EntityQuery query)
+  Option<Entities> getEntities(@NotNull EntityQuery query)
       throws DataFactoryException, NotBoundException, RemoteException;
 
   /**
@@ -116,7 +116,7 @@ public interface EntityStore extends Remote {
    * @throws NotBoundException
    * @throws RemoteException
    */
-  Boolean saveProperty(@NotNull DataFactoryProperty property)
+  Boolean saveProperty(@NotNull Property property)
       throws DataFactoryException, NotBoundException, RemoteException;
 
   /**
@@ -128,7 +128,7 @@ public interface EntityStore extends Remote {
    * @throws NotBoundException
    * @throws RemoteException
    */
-  Boolean removeProperty(@NotNull DataFactoryProperty property)
+  Boolean removeProperty(@NotNull Property property)
       throws DataFactoryException, NotBoundException, RemoteException;
 
   /**
@@ -152,6 +152,6 @@ public interface EntityStore extends Remote {
    * @throws NotBoundException
    * @throws RemoteException
    */
-  Option<DataFactoryEntityTypes> getEntityTypes(EntityTypeQuery query)
+  Option<EntityTypes> getEntityTypes(EntityTypeQuery query)
       throws DataFactoryException, NotBoundException, RemoteException;
 }

--- a/src/main/java/com/divroll/datafactory/repositories/impl/EntityStoreClientImpl.java
+++ b/src/main/java/com/divroll/datafactory/repositories/impl/EntityStoreClientImpl.java
@@ -19,10 +19,10 @@
  */
 package com.divroll.datafactory.repositories.impl;
 
-import com.divroll.datafactory.builders.DataFactoryEntities;
-import com.divroll.datafactory.builders.DataFactoryEntity;
-import com.divroll.datafactory.builders.DataFactoryEntityTypes;
-import com.divroll.datafactory.builders.DataFactoryProperty;
+import com.divroll.datafactory.builders.Entities;
+import com.divroll.datafactory.builders.Entity;
+import com.divroll.datafactory.builders.EntityTypes;
+import com.divroll.datafactory.builders.Property;
 import com.divroll.datafactory.builders.queries.EntityQuery;
 import com.divroll.datafactory.builders.queries.EntityTypeQuery;
 import com.divroll.datafactory.exceptions.DataFactoryException;
@@ -82,31 +82,31 @@ public class EntityStoreClientImpl implements EntityStore {
   }
 
   /**
-   * Saves the given DataFactoryEntity.
+   * Saves the given Entity.
    *
-   * @param entity The DataFactoryEntity to be saved. Cannot be null.
-   * @return An Option containing the saved DataFactoryEntity, or None if the save operation
+   * @param entity The Entity to be saved. Cannot be null.
+   * @return An Option containing the saved Entity, or None if the save operation
    * failed or the entity is invalid.
    * @throws DataFactoryException if there is an error in the data factory.
    * @throws NotBoundException if the EntityStore is not bound.
    * @throws RemoteException if a communication-related error occurs.
    */
-  @Override public Option<DataFactoryEntity> saveEntity(@NotNull final DataFactoryEntity entity)
+  @Override public Option<Entity> saveEntity(@NotNull final Entity entity)
       throws DataFactoryException, NotBoundException, RemoteException {
     return getEntityStore().saveEntity(entity);
   }
 
   /**
-   * Saves the given array of DataFactoryEntity objects.
+   * Saves the given array of Entity objects.
    *
-   * @param entities an array of DataFactoryEntity objects to be saved
-   * @return an Option containing the saved DataFactoryEntities or None if an error occurs
+   * @param entities an array of Entity objects to be saved
+   * @return an Option containing the saved Entities or None if an error occurs
    * @throws DataFactoryException if there is an error in the data factory system
    * @throws NotBoundException if the data factory is not bound
    * @throws RemoteException if a remote communication error occurs
    */
   @Override
-  public Option<DataFactoryEntities> saveEntities(@NotNull final DataFactoryEntity[] entities)
+  public Option<Entities> saveEntities(@NotNull final Entity[] entities)
       throws DataFactoryException, NotBoundException, RemoteException {
     return getEntityStore().saveEntities(entities);
   }
@@ -115,14 +115,14 @@ public class EntityStoreClientImpl implements EntityStore {
    * Retrieves an entity from the data factory system based on the given query.
    *
    * @param query The entity query used to retrieve the entity. Cannot be null.
-   * @return An {@code Option<DataFactoryEntity>} object representing the entity if found,
+   * @return An {@code Option<Entity>} object representing the entity if found,
    * otherwise an empty {@code Option}.
    * @throws DataFactoryException If there is an error retrieving the entity from
    * the data factory system.
    * @throws NotBoundException If the entity is not bound in the data factory system.
    * @throws RemoteException If a remote exception occurs during the retrieval of the entity.
    */
-  @Override public Option<DataFactoryEntity> getEntity(@NotNull final EntityQuery query)
+  @Override public Option<Entity> getEntity(@NotNull final EntityQuery query)
       throws DataFactoryException, NotBoundException, RemoteException {
     return getEntityStore().getEntity(query);
   }
@@ -136,7 +136,7 @@ public class EntityStoreClientImpl implements EntityStore {
    * @throws NotBoundException if the entity store is not bound
    * @throws RemoteException if a remote exception occurs during the operation
    */
-  @Override public Option<DataFactoryEntities> getEntities(@NotNull final EntityQuery query)
+  @Override public Option<Entities> getEntities(@NotNull final EntityQuery query)
       throws DataFactoryException, NotBoundException, RemoteException {
     return getEntityStore().getEntities(query);
   }
@@ -170,29 +170,29 @@ public class EntityStoreClientImpl implements EntityStore {
   }
 
   /**
-   * Saves a DataFactoryProperty to the entity store.
+   * Saves a Property to the entity store.
    *
-   * @param property The DataFactoryProperty to be saved.
+   * @param property The Property to be saved.
    * @return true if the property was saved successfully, false otherwise.
    * @throws DataFactoryException If there is an error in the data factory.
    * @throws NotBoundException If the entity store is not bound.
    * @throws RemoteException If a remote exception occurs.
    */
-  @Override public Boolean saveProperty(@NotNull final DataFactoryProperty property)
+  @Override public Boolean saveProperty(@NotNull final Property property)
       throws DataFactoryException, NotBoundException, RemoteException {
     return getEntityStore().saveProperty(property);
   }
 
   /**
-   * Removes a DataFactoryProperty from the entity store.
+   * Removes a Property from the entity store.
    *
-   * @param property The DataFactoryProperty to be removed. Cannot be null.
+   * @param property The Property to be removed. Cannot be null.
    * @return true if the property was removed successfully, false otherwise.
    * @throws DataFactoryException If there is an error in the data factory.
    * @throws NotBoundException If the entity store is not bound.
    * @throws RemoteException If a remote exception occurs during the removal process.
    */
-  @Override public Boolean removeProperty(@NotNull final DataFactoryProperty property)
+  @Override public Boolean removeProperty(@NotNull final Property property)
       throws DataFactoryException, NotBoundException, RemoteException {
     return getEntityStore().removeProperty(property);
   }
@@ -216,13 +216,13 @@ public class EntityStoreClientImpl implements EntityStore {
    *
    * @param query The EntityTypeQuery object specifying the criteria for the entity types
    *             to retrieve. Cannot be null.
-   * @return An Option<DataFactoryEntityTypes> representing the retrieved entity types,
+   * @return An Option<EntityTypes> representing the retrieved entity types,
    * or None if no entity types match the query.
    * @throws DataFactoryException If there is an error in the data factory.
    * @throws NotBoundException If the entity store is not bound.
    * @throws RemoteException If a remote exception occurs during the retrieval process.
    */
-  @Override public Option<DataFactoryEntityTypes> getEntityTypes(final EntityTypeQuery query)
+  @Override public Option<EntityTypes> getEntityTypes(final EntityTypeQuery query)
       throws DataFactoryException, NotBoundException, RemoteException {
       return getEntityStore().getEntityTypes(query);
   }

--- a/src/test/java/com/divroll/datafactory/DataFactoryClientTest.java
+++ b/src/test/java/com/divroll/datafactory/DataFactoryClientTest.java
@@ -19,9 +19,8 @@
  */
 package com.divroll.datafactory;
 
-import com.divroll.datafactory.builders.DataFactoryEntity;
-import com.divroll.datafactory.builders.DataFactoryEntityBuilder;
-import com.divroll.datafactory.exceptions.DataFactoryException;
+import com.divroll.datafactory.builders.Entity;
+import com.divroll.datafactory.builders.EntityBuilder;
 import com.divroll.datafactory.repositories.EntityStore;
 
 import java.rmi.NotBoundException;
@@ -69,13 +68,13 @@ public class DataFactoryClientTest {
     EntityStore entityStore = client.getEntityStore();
     Assert.assertNotNull(entityStore);
 
-    DataFactoryEntity entity = new DataFactoryEntityBuilder()
+    Entity entity = new EntityBuilder()
             .environment(TestEnvironment.getEnvironment())
             .entityType("Foo")
             .putPropertyMap("foo", "bar")
             .build();
 
-    DataFactoryEntity dataFactoryEntity = entityStore.saveEntity(entity).get();
+    Entity dataFactoryEntity = entityStore.saveEntity(entity).get();
     Assert.assertNotNull(dataFactoryEntity);
     Assert.assertNotNull(dataFactoryEntity.entityId());
     Assert.assertEquals("bar", dataFactoryEntity.propertyMap().get("foo"));

--- a/src/test/java/com/divroll/datafactory/actions/BlobRemoveActionTest.java
+++ b/src/test/java/com/divroll/datafactory/actions/BlobRemoveActionTest.java
@@ -47,8 +47,8 @@ public class BlobRemoveActionTest extends BaseTest {
     /**
      * Test case for the method testBlobRemove.
      * The method tests a scenario where an entity's blob is removed.
-     * It creates a DataFactoryEntity with a blob, then removes the blob using the entityStore.
-     * The method asserts that the blob is removed from the saved DataFactoryEntity.
+     * It creates a Entity with a blob, then removes the blob using the entityStore.
+     * The method asserts that the blob is removed from the saved Entity.
      *
      * @throws Exception if an error occurs during the test
      */
@@ -57,20 +57,20 @@ public class BlobRemoveActionTest extends BaseTest {
         String environment = getEnvironment();
 
         // Create a blob we can test
-        DataFactoryEntity dataFactoryEntity = createEntityWithBlob(environment);
+        Entity entity = createEntityWithBlob(environment);
 
-        String entityId = dataFactoryEntity.entityId();
-        String entityType = dataFactoryEntity.entityType();
-        String[] blobNames = dataFactoryEntity.blobNames();
+        String entityId = entity.entityId();
+        String entityType = entity.entityType();
+        String[] blobNames = entity.blobNames();
 
         assertNotNull(entityId);
         assertNotNull(entityType);
         assertNotNull(blobNames);
         assertTrue(Arrays.asList(blobNames).contains("photo"));
 
-        DataFactoryEntity singleEntityWithBlob = entityStore.getEntity(new EntityQueryBuilder()
+        Entity singleEntityWithBlob = entityStore.getEntity(new EntityQueryBuilder()
                 .environment(environment)
-                .entityId(dataFactoryEntity.entityId())
+                .entityId(entity.entityId())
                 .addBlobQueries(new BlobQueryBuilder()
                         .blobName("photo")
                         .include(true)
@@ -92,13 +92,13 @@ public class BlobRemoveActionTest extends BaseTest {
                         .build())
                 .build();
 
-        DataFactoryEntities entities = entityStore.getEntities(entityQuery).get();
+        Entities entities = entityStore.getEntities(entityQuery).get();
 
         assertNotNull(entities);
         assertTrue(entities.count() == 1);
         assertNotNull(entities.entities());
 
-        DataFactoryEntity entityWithBlob = entities.entities().stream().findFirst().get();
+        Entity entityWithBlob = entities.entities().stream().findFirst().get();
         assertNotNull(entityWithBlob);
         assertNotNull(entityWithBlob.entityId());
         assertNotNull(entityWithBlob.entityType());
@@ -111,7 +111,7 @@ public class BlobRemoveActionTest extends BaseTest {
          assertTrue(wasRemoved);
 
          // Get the entity by blob name to test
-         DataFactoryEntities shouldBeEmpty = entityStore.getEntities(entityQuery).get();
+         Entities shouldBeEmpty = entityStore.getEntities(entityQuery).get();
          assertNotNull(shouldBeEmpty);
          assertTrue(shouldBeEmpty.count() == 0);
     }
@@ -119,11 +119,11 @@ public class BlobRemoveActionTest extends BaseTest {
     /**
      * Test case for the method testRemoveBlobWithAction.
      * The method tests a scenario where an entity's blob is replaced with a new blob effectively removing the old blob.
-     * It creates a DataFactoryEntity with a blob, then creates a BlobRemoveAction with the blob name "photo".
-     * The BlobRemoveAction is added as an action to the DataFactoryEntity.
-     * A new blob named "newPhoto" is added to the DataFactoryEntity.
-     * The DataFactoryEntity is saved using the entityStore.
-     * The method asserts that the old blob "photo" is removed and the new blob "newPhoto" is present in the saved DataFactoryEntity.
+     * It creates a Entity with a blob, then creates a BlobRemoveAction with the blob name "photo".
+     * The BlobRemoveAction is added as an action to the Entity.
+     * A new blob named "newPhoto" is added to the Entity.
+     * The Entity is saved using the entityStore.
+     * The method asserts that the old blob "photo" is removed and the new blob "newPhoto" is present in the saved Entity.
      *
      * @throws Exception if an error occurs during the test
      */
@@ -131,25 +131,25 @@ public class BlobRemoveActionTest extends BaseTest {
     public void testRemoveBlobWithAction() throws Exception {
         String environment = getEnvironment();
 
-        DataFactoryEntity dataFactoryEntity = createEntityWithBlob(environment);
-        assertNotNull(dataFactoryEntity.entityId());
+        Entity entity = createEntityWithBlob(environment);
+        assertNotNull(entity.entityId());
 
         // Test a scenario where the entity will be replaced with a new blob effectively removing the old blob
         BlobRemoveAction blobRemoveAction = ImmutableBlobRemoveAction.builder()
                 .addAllBlobNames(Arrays.asList("photo"))
                 .build();
 
-        dataFactoryEntity = new DataFactoryEntityBuilder()
+        entity = new EntityBuilder()
                 .environment(environment)
                 .entityType(ENTITY_TYPE)
-                .entityId(dataFactoryEntity.entityId())
+                .entityId(entity.entityId())
                 .addActions(blobRemoveAction)
-                .addBlobs(new DataFactoryBlobBuilder()
+                .addBlobs(new BlobBuilder()
                         .blobName("newPhoto")
                         .blobStream(new SimpleRemoteInputStream(ByteSource.wrap("New Mock Image".getBytes()).openStream()))
                         .build())
                 .build();
-        String[] blobName = entityStore.saveEntity(dataFactoryEntity).get().blobNames();
+        String[] blobName = entityStore.saveEntity(entity).get().blobNames();
 
         // Test if the blob was removed
         assertFalse(Arrays.asList(blobName).contains("photo"));
@@ -160,7 +160,7 @@ public class BlobRemoveActionTest extends BaseTest {
     public void testFalseOnNonExistentBlobRemove() throws Exception {
         String environment = getEnvironment();
 
-        DataFactoryEntity dataFactoryEntity = createEntityWithBlob(environment);
+        Entity entity = createEntityWithBlob(environment);
 
         EntityQuery entityQuery = new EntityQueryBuilder()
                 .environment(environment)
@@ -190,8 +190,8 @@ public class BlobRemoveActionTest extends BaseTest {
         String environment = getEnvironment();
 
         // Create an entity with multiple blobs
-        DataFactoryEntity dataFactoryEntity = createEntityWithMultipleBlobs(environment);
-        assertNotNull(dataFactoryEntity.entityId());
+        Entity entity = createEntityWithMultipleBlobs(environment);
+        assertNotNull(entity.entityId());
 
         // Create a query with multiple non-existing blob names
         EntityQuery entityQuery = new EntityQueryBuilder()
@@ -220,16 +220,16 @@ public class BlobRemoveActionTest extends BaseTest {
                 .build();
 
         // Get the entity by blob names to test
-        DataFactoryEntities shouldNotBeEmpty = entityStore.getEntities(existingBlobsQuery).get();
+        Entities shouldNotBeEmpty = entityStore.getEntities(existingBlobsQuery).get();
 
         // Assert that the entity with multiple blobs is still intact and was not affected
         assertNotNull(shouldNotBeEmpty);
         assertTrue(shouldNotBeEmpty.count() == 1);
-        assertEquals(shouldNotBeEmpty.entities().stream().findFirst().get().entityId(), dataFactoryEntity.entityId());
+        assertEquals(shouldNotBeEmpty.entities().stream().findFirst().get().entityId(), entity.entityId());
     }
 
     /**
-     * This method tests the removal of multiple blobs from a DataFactoryEntity at once.
+     * This method tests the removal of multiple blobs from a Entity at once.
      * It creates an entity with multiple blobs and then removes those blobs using the entityStore.
      * The method asserts that the blobs were successfully removed from the entity.
      *
@@ -240,7 +240,7 @@ public class BlobRemoveActionTest extends BaseTest {
         String environment = getEnvironment();
 
         // Create an entity with multiple blobs
-        DataFactoryEntity dataFactoryEntity = createEntityWithMultipleBlobs(environment);
+        Entity entity = createEntityWithMultipleBlobs(environment);
 
         // Build the query that will be used for both checking the entity with blobs and removing them later
         EntityQuery entityQuery = new EntityQueryBuilder()
@@ -257,14 +257,14 @@ public class BlobRemoveActionTest extends BaseTest {
         assertTrue(wereRemoved);
 
         // Get the entity by blob names to test
-        DataFactoryEntities shouldBeEmpty = entityStore.getEntities(entityQuery).get();
+        Entities shouldBeEmpty = entityStore.getEntities(entityQuery).get();
         assertNotNull(shouldBeEmpty);
         assertTrue(shouldBeEmpty.count() == 0);
     }
 
     /**
-     * Test case for removing a blob from an empty DataFactoryEntity.
-     * It creates an empty DataFactoryEntity and attempts to remove a non-existing blob.
+     * Test case for removing a blob from an empty Entity.
+     * It creates an empty Entity and attempts to remove a non-existing blob.
      * The method asserts that the removal is not successful.
      *
      * @throws Exception if an error occurs during the test
@@ -273,7 +273,7 @@ public class BlobRemoveActionTest extends BaseTest {
     public void testRemoveBlobFromEmptyEntity() throws Exception {
         String environment = getEnvironment();
 
-        DataFactoryEntity emptyEntity = new DataFactoryEntityBuilder()
+        Entity emptyEntity = new EntityBuilder()
                 .environment(environment)
                 .entityType(ENTITY_TYPE)
                 .build();
@@ -318,66 +318,66 @@ public class BlobRemoveActionTest extends BaseTest {
     }
 
     /**
-     * Creates a DataFactoryEntity with multiple blobs.
+     * Creates a Entity with multiple blobs.
      *
-     * @return The created DataFactoryEntity.
+     * @return The created Entity.
      * @throws IOException If an I/O error occurs.
      * @throws NotBoundException If the object being called is not bound to this registry.
      */
-    private DataFactoryEntity createEntityWithMultipleBlobs(String environment) throws IOException, NotBoundException {
-        DataFactoryBlob blob1 = new DataFactoryBlobBuilder()
+    private Entity createEntityWithMultipleBlobs(String environment) throws IOException, NotBoundException {
+        Blob blob1 = new BlobBuilder()
                 .blobName("photo1")
                 .blobStream(new SimpleRemoteInputStream(ByteSource.wrap("Mock Image 1".getBytes()).openStream()))
                 .build();
-        DataFactoryBlob blob2 = new DataFactoryBlobBuilder()
+        Blob blob2 = new BlobBuilder()
                 .blobName("photo2")
                 .blobStream(new SimpleRemoteInputStream(ByteSource.wrap("Mock Image 2".getBytes()).openStream()))
                 .build();
-        DataFactoryBlob blob3 = new DataFactoryBlobBuilder()
+        Blob blob3 = new BlobBuilder()
                 .blobName("photo3")
                 .blobStream(new SimpleRemoteInputStream(ByteSource.wrap("Mock Image 3".getBytes()).openStream()))
                 .build();
-        DataFactoryEntity dataFactoryEntity = new DataFactoryEntityBuilder()
+        Entity entity = new EntityBuilder()
                 .environment(environment)
                 .entityType(ENTITY_TYPE)
                 .addBlobs(blob1, blob2, blob3)
                 .build();
-        dataFactoryEntity = entityStore.saveEntity(dataFactoryEntity).get();
-        return dataFactoryEntity;
+        entity = entityStore.saveEntity(entity).get();
+        return entity;
     }
 
     /**
-     * Creates a DataFactoryEntity with a blob.
+     * Creates a Entity with a blob.
      *
-     * @return The created DataFactoryEntity.
+     * @return The created Entity.
      * @throws IOException If an I/O error occurs.
      * @throws NotBoundException If the object being called is not bound to this registry.
      */
-    private DataFactoryEntity createEntityWithBlob(String environment) throws IOException, NotBoundException {
-        DataFactoryBlob blob = new DataFactoryBlobBuilder()
+    private Entity createEntityWithBlob(String environment) throws IOException, NotBoundException {
+        Blob blob = new BlobBuilder()
                 .blobName("photo")
                 .blobStream(new SimpleRemoteInputStream(ByteSource.wrap("Mock Image".getBytes()).openStream()))
                 .build();
-        DataFactoryEntity dataFactoryEntity = new DataFactoryEntityBuilder()
+        Entity entity = new EntityBuilder()
                 .environment(environment)
                 .entityType(ENTITY_TYPE)
                 .addBlobs(blob)
                 .build();
-        dataFactoryEntity = entityStore.saveEntity(dataFactoryEntity).get();
-        return dataFactoryEntity;
+        entity = entityStore.saveEntity(entity).get();
+        return entity;
     }
 
     /**
-     * Retrieves the content of a blob with the specified name from the provided DataFactoryEntity.
+     * Retrieves the content of a blob with the specified name from the provided Entity.
      *
-     * @param entityWithBlob The DataFactoryEntity that contains the blob.
+     * @param entityWithBlob The Entity that contains the blob.
      * @param blobName The name of the blob.
      * @return The content of the blob as a string, or null if the blob is not found.
      * @throws Exception if an error occurs while retrieving the blob content.
      */
-    private String getBlobString(DataFactoryEntity entityWithBlob, String blobName) throws Exception {
+    private String getBlobString(Entity entityWithBlob, String blobName) throws Exception {
         String blobString = null;
-        for (DataFactoryBlob b : entityWithBlob.blobs()) {
+        for (Blob b : entityWithBlob.blobs()) {
             if (b.blobName().equals(blobName)) {
                 RemoteInputStream remoteInputStream = b.blobStream();
                 blobString =

--- a/src/test/java/com/divroll/datafactory/actions/CustomActionTest.java
+++ b/src/test/java/com/divroll/datafactory/actions/CustomActionTest.java
@@ -21,8 +21,8 @@ package com.divroll.datafactory.actions;
 
 import com.divroll.datafactory.DataFactory;
 import com.divroll.datafactory.TestEnvironment;
-import com.divroll.datafactory.builders.DataFactoryEntity;
-import com.divroll.datafactory.builders.DataFactoryEntityBuilder;
+import com.divroll.datafactory.builders.Entity;
+import com.divroll.datafactory.builders.EntityBuilder;
 import com.divroll.datafactory.builders.queries.EntityQuery;
 import com.divroll.datafactory.builders.queries.EntityQueryBuilder;
 import com.divroll.datafactory.repositories.EntityStore;
@@ -41,22 +41,22 @@ public class CustomActionTest {
   public void testCustomAction() throws Exception {
     String environment = TestEnvironment.getEnvironment();
     EntityStore entityStore = DataFactory.getInstance().getEntityStore();
-    DataFactoryEntity dataFactoryEntity = new DataFactoryEntityBuilder()
+    Entity entity = new EntityBuilder()
         .environment(environment)
         .entityType("Room")
         .putPropertyMap("likes", 10)
         .build();
-    dataFactoryEntity = entityStore.saveEntity(dataFactoryEntity).get();
-    entityStore.saveEntity(new DataFactoryEntityBuilder()
+    entity = entityStore.saveEntity(entity).get();
+    entityStore.saveEntity(new EntityBuilder()
         .environment(environment)
-        .entityId(dataFactoryEntity.entityId())
+        .entityId(entity.entityId())
         .addActions(new IncrementLikesAction(2990))
         .build());
     EntityQuery entityQuery = new EntityQueryBuilder()
         .environment(environment)
-        .entityId(dataFactoryEntity.entityId())
+        .entityId(entity.entityId())
         .build();
-    DataFactoryEntity updatedEntity = entityStore.getEntity(entityQuery).get();
+    Entity updatedEntity = entityStore.getEntity(entityQuery).get();
     assertEquals(3000, updatedEntity.propertyMap().get("likes"));
   }
 }

--- a/src/test/java/com/divroll/datafactory/conditions/CustomConditionTest.java
+++ b/src/test/java/com/divroll/datafactory/conditions/CustomConditionTest.java
@@ -22,8 +22,8 @@ package com.divroll.datafactory.conditions;
 import com.divroll.datafactory.DataFactory;
 import com.divroll.datafactory.TestEnvironment;
 import com.divroll.datafactory.actions.IncrementLikesAction;
-import com.divroll.datafactory.builders.DataFactoryEntity;
-import com.divroll.datafactory.builders.DataFactoryEntityBuilder;
+import com.divroll.datafactory.builders.Entity;
+import com.divroll.datafactory.builders.EntityBuilder;
 import com.divroll.datafactory.conditions.exceptions.UnsatisfiedConditionException;
 import com.divroll.datafactory.repositories.EntityStore;
 import org.junit.Test;
@@ -42,16 +42,16 @@ public class CustomConditionTest {
   public void testCustomConditionShouldFail() throws Exception {
     String environment = TestEnvironment.getEnvironment();
     EntityStore entityStore = DataFactory.getInstance().getEntityStore();
-    DataFactoryEntity dataFactoryEntity = entityStore.saveEntity(new DataFactoryEntityBuilder()
+    Entity entity = entityStore.saveEntity(new EntityBuilder()
         .environment(environment)
         .entityType("Room")
         .putPropertyMap("address", "Room 123, 456 Street, 789 Avenue")
         .build()).get();
 
     // Update entity if HasBeenLikedCondition is satisfied
-    DataFactoryEntity updated = entityStore.saveEntity(new DataFactoryEntityBuilder()
+    Entity updated = entityStore.saveEntity(new EntityBuilder()
         .environment(environment)
-        .entityId(dataFactoryEntity.entityId())
+        .entityId(entity.entityId())
         .addConditions(new HasBeenLikedCondition())
         .addActions(new IncrementLikesAction(100))
         .build()).get();
@@ -61,22 +61,22 @@ public class CustomConditionTest {
   public void testCustomCondition() throws Exception {
     String environment = TestEnvironment.getEnvironment();
     EntityStore entityStore = DataFactory.getInstance().getEntityStore();
-    DataFactoryEntity dataFactoryEntity = entityStore.saveEntity(new DataFactoryEntityBuilder()
+    Entity entity = entityStore.saveEntity(new EntityBuilder()
         .environment(environment)
         .entityType("Room")
         .putPropertyMap("address", "Room 123, 456 Street, 789 Avenue")
         .build()).get();
 
-    entityStore.saveEntity(new DataFactoryEntityBuilder()
+    entityStore.saveEntity(new EntityBuilder()
         .environment(environment)
-        .entityId(dataFactoryEntity.entityId())
+        .entityId(entity.entityId())
         .putPropertyMap("likes", 1)
         .build()).get();
 
     // Update entity if HasBeenLikedCondition is satisfied
-    DataFactoryEntity shouldBeUpdated = entityStore.saveEntity(new DataFactoryEntityBuilder()
+    Entity shouldBeUpdated = entityStore.saveEntity(new EntityBuilder()
         .environment(environment)
-        .entityId(dataFactoryEntity.entityId())
+        .entityId(entity.entityId())
         .addConditions(new HasBeenLikedCondition())
         .addActions(new IncrementLikesAction(100))
         .build()).get();

--- a/src/test/java/com/divroll/datafactory/conditions/PropertyContainsConditionPerfTest.java
+++ b/src/test/java/com/divroll/datafactory/conditions/PropertyContainsConditionPerfTest.java
@@ -21,9 +21,8 @@ package com.divroll.datafactory.conditions;
 
 import com.divroll.datafactory.DataFactory;
 import com.divroll.datafactory.TestEnvironment;
-import com.divroll.datafactory.builders.DataFactoryEntities;
-import com.divroll.datafactory.builders.DataFactoryEntity;
-import com.divroll.datafactory.builders.DataFactoryEntityBuilder;
+import com.divroll.datafactory.builders.Entities;
+import com.divroll.datafactory.builders.EntityBuilder;
 import com.divroll.datafactory.builders.queries.EntityQuery;
 import com.divroll.datafactory.builders.queries.EntityQueryBuilder;
 import com.divroll.datafactory.repositories.EntityStore;
@@ -54,7 +53,7 @@ public class PropertyContainsConditionPerfTest {
     keywords.addItem("banana");
     long start = System.currentTimeMillis();
     for (int i = 0; i < 1000; i++) {
-      entityStore.saveEntity(new DataFactoryEntityBuilder()
+      entityStore.saveEntity(new EntityBuilder()
           .environment(environment)
           .entityType("Foo")
           .putPropertyMap("keywords", keywords)
@@ -64,7 +63,7 @@ public class PropertyContainsConditionPerfTest {
     newKeywords.addItem("apple");
     newKeywords.addItem("banana");
     newKeywords.addItem("carrot");
-    entityStore.saveEntity(new DataFactoryEntityBuilder()
+    entityStore.saveEntity(new EntityBuilder()
         .environment(environment)
         .entityType("Foo")
         .putPropertyMap("keywords", newKeywords)
@@ -80,7 +79,7 @@ public class PropertyContainsConditionPerfTest {
             .innerPropertyValue("carrot")
             .build())
         .build();
-    DataFactoryEntities entities = entityStore.getEntities(entityQuery).get();
+    Entities entities = entityStore.getEntities(entityQuery).get();
     time = System.currentTimeMillis() - start;
     LOG.info("Time to get complete (ms): " + time);
     assertEquals(1L, entities.entities().size());

--- a/src/test/java/com/divroll/datafactory/conditions/PropertyContainsConditionTest.java
+++ b/src/test/java/com/divroll/datafactory/conditions/PropertyContainsConditionTest.java
@@ -21,8 +21,8 @@ package com.divroll.datafactory.conditions;
 
 import com.divroll.datafactory.DataFactory;
 import com.divroll.datafactory.TestEnvironment;
-import com.divroll.datafactory.builders.DataFactoryEntity;
-import com.divroll.datafactory.builders.DataFactoryEntityBuilder;
+import com.divroll.datafactory.builders.Entity;
+import com.divroll.datafactory.builders.EntityBuilder;
 import com.divroll.datafactory.builders.queries.EntityQuery;
 import com.divroll.datafactory.builders.queries.EntityQueryBuilder;
 import com.divroll.datafactory.repositories.EntityStore;
@@ -49,14 +49,14 @@ public class PropertyContainsConditionTest {
     keywords.addItem("room");
     keywords.addItem("street");
     keywords.addItem("avenue");
-    DataFactoryEntity dataFactoryEntity = new DataFactoryEntityBuilder()
+    Entity entity = new EntityBuilder()
         .environment(environment)
         .entityType("Room")
         .putPropertyMap("address", "Room 123, 456 Street, 789 Avenue")
         .putPropertyMap("keywords", keywords)
         .build();
-    dataFactoryEntity = entityStore.saveEntity(dataFactoryEntity).get();
-    assertNotNull(dataFactoryEntity.entityId());
+    entity = entityStore.saveEntity(entity).get();
+    assertNotNull(entity.entityId());
     EntityQuery entityQuery = new EntityQueryBuilder()
         .environment(environment)
         .entityType("Room")
@@ -65,9 +65,9 @@ public class PropertyContainsConditionTest {
             .innerPropertyValue("room")
             .build())
         .build();
-    DataFactoryEntity entityWithKeywords = entityStore.getEntity(entityQuery).get();
+    Entity entityWithKeywords = entityStore.getEntity(entityQuery).get();
     assertNotNull(entityWithKeywords);
-    assertEquals(dataFactoryEntity.entityId(), entityWithKeywords.entityId());
+    assertEquals(entity.entityId(), entityWithKeywords.entityId());
   }
 
   @Test(expected = NoSuchElementException.class)
@@ -78,14 +78,14 @@ public class PropertyContainsConditionTest {
     keywords.addItem("room");
     keywords.addItem("street");
     keywords.addItem("avenue");
-    DataFactoryEntity dataFactoryEntity = new DataFactoryEntityBuilder()
+    Entity entity = new EntityBuilder()
         .environment(environment)
         .entityType("Room")
         .putPropertyMap("address", "Room 123, 456 Street, 789 Avenue")
         .putPropertyMap("keywords", keywords)
         .build();
-    dataFactoryEntity = entityStore.saveEntity(dataFactoryEntity).get();
-    assertNotNull(dataFactoryEntity.entityId());
+    entity = entityStore.saveEntity(entity).get();
+    assertNotNull(entity.entityId());
     EntityQuery entityQuery = new EntityQueryBuilder()
         .environment(environment)
         .entityType("Room")
@@ -94,7 +94,7 @@ public class PropertyContainsConditionTest {
             .innerPropertyValue("unknown")
             .build())
         .build();
-    DataFactoryEntity entityWithKeywords = entityStore.getEntity(entityQuery).get();
+    Entity entityWithKeywords = entityStore.getEntity(entityQuery).get();
     assertNull(entityWithKeywords);
   }
 }

--- a/src/test/java/com/divroll/datafactory/conditions/PropertyEqualConditionPerfTest.java
+++ b/src/test/java/com/divroll/datafactory/conditions/PropertyEqualConditionPerfTest.java
@@ -21,8 +21,8 @@ package com.divroll.datafactory.conditions;
 
 import com.divroll.datafactory.DataFactory;
 import com.divroll.datafactory.TestEnvironment;
-import com.divroll.datafactory.builders.DataFactoryEntities;
-import com.divroll.datafactory.builders.DataFactoryEntityBuilder;
+import com.divroll.datafactory.builders.Entities;
+import com.divroll.datafactory.builders.EntityBuilder;
 import com.divroll.datafactory.builders.queries.EntityQuery;
 import com.divroll.datafactory.builders.queries.EntityQueryBuilder;
 import com.divroll.datafactory.repositories.EntityStore;
@@ -48,13 +48,13 @@ public class PropertyEqualConditionPerfTest {
     String environment = TestEnvironment.getEnvironment();
     long start = System.currentTimeMillis();
     for (int i = 0; i < 1000; i++) {
-      entityStore.saveEntity(new DataFactoryEntityBuilder()
+      entityStore.saveEntity(new EntityBuilder()
           .environment(environment)
           .entityType("Foo")
           .putPropertyMap("foo", "bar")
           .build()).get();
     }
-    entityStore.saveEntity(new DataFactoryEntityBuilder()
+    entityStore.saveEntity(new EntityBuilder()
         .environment(environment)
         .entityType("Foo")
         .putPropertyMap("baz", "fuu")
@@ -70,7 +70,7 @@ public class PropertyEqualConditionPerfTest {
             .build())
         .build();
     //System.out.println(new Gson().toJson(entityQuery));
-    DataFactoryEntities entities = entityStore.getEntities(entityQuery).get();
+    Entities entities = entityStore.getEntities(entityQuery).get();
     time = System.currentTimeMillis() - start;
     LOG.info("Time to get complete (ms): " + time);
     assertEquals(1L, entities.entities().size());

--- a/src/test/java/com/divroll/datafactory/conditions/PropertyLocalTimeRangeConditionTest.java
+++ b/src/test/java/com/divroll/datafactory/conditions/PropertyLocalTimeRangeConditionTest.java
@@ -22,8 +22,8 @@ package com.divroll.datafactory.conditions;
 import com.divroll.datafactory.DataFactory;
 import com.divroll.datafactory.LocalTimeRange;
 import com.divroll.datafactory.TestEnvironment;
-import com.divroll.datafactory.builders.DataFactoryEntities;
-import com.divroll.datafactory.builders.DataFactoryEntityBuilder;
+import com.divroll.datafactory.builders.Entities;
+import com.divroll.datafactory.builders.EntityBuilder;
 import com.divroll.datafactory.builders.queries.EntityQueryBuilder;
 import com.divroll.datafactory.repositories.EntityStore;
 import java.rmi.NotBoundException;
@@ -37,35 +37,35 @@ public class PropertyLocalTimeRangeConditionTest {
   public void testInRangeCondition() throws RemoteException, NotBoundException {
     EntityStore entityStore = DataFactory.getInstance().getEntityStore();
     String environment = TestEnvironment.getEnvironment();
-    entityStore.saveEntity(new DataFactoryEntityBuilder()
+    entityStore.saveEntity(new EntityBuilder()
         .environment(environment)
         .entityType("Room")
         .putPropertyMap("SUNDAY",
             new LocalTimeRange(LocalTime.parse("07:00"), LocalTime.parse("18:00")))
         .build()).get();
 
-    entityStore.saveEntity(new DataFactoryEntityBuilder()
+    entityStore.saveEntity(new EntityBuilder()
         .environment(environment)
         .entityType("Room")
         .putPropertyMap("SUNDAY",
             new LocalTimeRange(LocalTime.parse("08:00"), LocalTime.parse("22:00")))
         .build()).get();
 
-    entityStore.saveEntity(new DataFactoryEntityBuilder()
+    entityStore.saveEntity(new EntityBuilder()
         .environment(environment)
         .entityType("Room")
         .putPropertyMap("SUNDAY",
             new LocalTimeRange(LocalTime.parse("01:00"), LocalTime.parse("06:00")))
         .build()).get();
 
-    entityStore.saveEntity(new DataFactoryEntityBuilder()
+    entityStore.saveEntity(new EntityBuilder()
         .environment(environment)
         .entityType("Room")
         .putPropertyMap("MONDAY",
             new LocalTimeRange(LocalTime.parse("07:00"), LocalTime.parse("23:59")))
         .build()).get();
 
-    DataFactoryEntities dataFactoryEntities = entityStore.getEntities(new EntityQueryBuilder()
+    Entities entities = entityStore.getEntities(new EntityQueryBuilder()
         .environment(environment)
         .entityType("Room")
         .addConditions(new PropertyLocalTimeRangeConditionBuilder()
@@ -74,11 +74,11 @@ public class PropertyLocalTimeRangeConditionTest {
             .upper(LocalTime.parse("11:00"))
             .build())
         .build()).get();
-    Assert.assertNotNull(dataFactoryEntities);
-    Assert.assertNotNull(dataFactoryEntities.entities());
-    Assert.assertEquals(2L, dataFactoryEntities.count().longValue());
+    Assert.assertNotNull(entities);
+    Assert.assertNotNull(entities.entities());
+    Assert.assertEquals(2L, entities.count().longValue());
 
-    DataFactoryEntities dataFactoryEntities2 = entityStore.getEntities(new EntityQueryBuilder()
+    Entities entities2 = entityStore.getEntities(new EntityQueryBuilder()
         .environment(environment)
         .entityType("Room")
         .addConditions(new PropertyLocalTimeRangeConditionBuilder()
@@ -87,11 +87,11 @@ public class PropertyLocalTimeRangeConditionTest {
             .upper(LocalTime.parse("20:00"))
             .build())
         .build()).get();
-    Assert.assertNotNull(dataFactoryEntities2);
-    Assert.assertNotNull(dataFactoryEntities2.entities());
-    Assert.assertEquals(1L, dataFactoryEntities2.count().longValue());
+    Assert.assertNotNull(entities2);
+    Assert.assertNotNull(entities2.entities());
+    Assert.assertEquals(1L, entities2.count().longValue());
 
-    DataFactoryEntities dataFactoryEntities3 = entityStore.getEntities(new EntityQueryBuilder()
+    Entities entities3 = entityStore.getEntities(new EntityQueryBuilder()
         .environment(environment)
         .entityType("Room")
         .addConditions(new PropertyLocalTimeRangeConditionBuilder()
@@ -100,11 +100,11 @@ public class PropertyLocalTimeRangeConditionTest {
             .upper(LocalTime.parse("06:00"))
             .build())
         .build()).get();
-    Assert.assertNotNull(dataFactoryEntities3);
-    Assert.assertNotNull(dataFactoryEntities3.entities());
-    Assert.assertEquals(0L, dataFactoryEntities3.count().longValue());
+    Assert.assertNotNull(entities3);
+    Assert.assertNotNull(entities3.entities());
+    Assert.assertEquals(0L, entities3.count().longValue());
 
-    DataFactoryEntities dataFactoryEntities4 = entityStore.getEntities(new EntityQueryBuilder()
+    Entities entities4 = entityStore.getEntities(new EntityQueryBuilder()
         .environment(environment)
         .entityType("Room")
         .addConditions(new PropertyLocalTimeRangeConditionBuilder()
@@ -113,8 +113,8 @@ public class PropertyLocalTimeRangeConditionTest {
             .upper(LocalTime.parse("23:59"))
             .build())
         .build()).get();
-    Assert.assertNotNull(dataFactoryEntities4);
-    Assert.assertNotNull(dataFactoryEntities4.entities());
-    Assert.assertEquals(1L, dataFactoryEntities4.count().longValue());
+    Assert.assertNotNull(entities4);
+    Assert.assertNotNull(entities4.entities());
+    Assert.assertEquals(1L, entities4.count().longValue());
   }
 }

--- a/src/test/java/com/divroll/datafactory/conditions/PropertyNearbyConditionClientPerfTest.java
+++ b/src/test/java/com/divroll/datafactory/conditions/PropertyNearbyConditionClientPerfTest.java
@@ -20,9 +20,9 @@
 package com.divroll.datafactory.conditions;
 
 import com.divroll.datafactory.*;
-import com.divroll.datafactory.builders.DataFactoryEntities;
-import com.divroll.datafactory.builders.DataFactoryEntity;
-import com.divroll.datafactory.builders.DataFactoryEntityBuilder;
+import com.divroll.datafactory.builders.Entities;
+import com.divroll.datafactory.builders.Entity;
+import com.divroll.datafactory.builders.EntityBuilder;
 import com.divroll.datafactory.builders.queries.EntityQuery;
 import com.divroll.datafactory.builders.queries.EntityQueryBuilder;
 import com.divroll.datafactory.repositories.EntityStore;
@@ -79,20 +79,20 @@ public class PropertyNearbyConditionClientPerfTest {
     long start = System.currentTimeMillis();
 
     for (int i = 0; i < 999; i++) {
-      entityStore.saveEntity(new DataFactoryEntityBuilder()
+      entityStore.saveEntity(new EntityBuilder()
           .environment(environment)
           .entityType("Room")
           .putPropertyMap("geoLocation", new GeoPoint(120.954228, 14.301893))
           .build()).get();
     }
 
-    entityStore.saveEntity(new DataFactoryEntityBuilder()
+    entityStore.saveEntity(new EntityBuilder()
         .environment(environment)
         .entityType("Room")
         .putPropertyMap("geoLocation", new GeoPoint(120.976187, 14.581310))
         .build()).get();
 
-    DataFactoryEntities dataFactoryEntities =
+    Entities dataFactoryEntities =
         entityStore.getEntities(new EntityQueryBuilder()
             .environment(environment)
             .entityType("Room")
@@ -104,7 +104,7 @@ public class PropertyNearbyConditionClientPerfTest {
     long time = System.currentTimeMillis() - start;
     LOG.info("Time to save complete (ms): " + time);
     start = System.currentTimeMillis();
-    List<DataFactoryEntity> matched = new ArrayList<>();
+    List<Entity> matched = new ArrayList<>();
     List<Long> times = new ArrayList<>();
 
     boolean hasMore = true;
@@ -124,7 +124,7 @@ public class PropertyNearbyConditionClientPerfTest {
           .offset(offset)
           .max(max)
           .build();
-      DataFactoryEntities entities = entityStore.getEntities(entityQuery).get();
+      Entities entities = entityStore.getEntities(entityQuery).get();
       matched.addAll(entities.entities());
       time = System.currentTimeMillis() - start;
       times.add(time);
@@ -148,7 +148,7 @@ public class PropertyNearbyConditionClientPerfTest {
     String environment = TestEnvironment.getEnvironment();
     EntityStore entityStore = DataFactoryClient.getInstance(TestEnvironment.getDomain(), TestEnvironment.getPort()).getEntityStore();
 
-    DataFactoryEntity firstLocation = new DataFactoryEntityBuilder()
+    Entity firstLocation = new EntityBuilder()
         .environment(environment)
         .entityType("Room")
         .putPropertyMap("address", "Room 123, 456 Street, 789 Avenue")
@@ -157,7 +157,7 @@ public class PropertyNearbyConditionClientPerfTest {
     firstLocation = entityStore.saveEntity(firstLocation).get();
     assertNotNull(firstLocation.entityId());
     for(int i=0;i<10000;i++){
-      DataFactoryEntity secondLocation = new DataFactoryEntityBuilder()
+      Entity secondLocation = new EntityBuilder()
           .environment(environment)
           .entityType("Room")
           .putPropertyMap("address", "Room 456, 789 Street, 012 Avenue")
@@ -166,7 +166,7 @@ public class PropertyNearbyConditionClientPerfTest {
       secondLocation = entityStore.saveEntity(secondLocation).get();
       //assertNotNull(secondLocation.entityId());
     }
-    DataFactoryEntity thirdLocation = new DataFactoryEntityBuilder()
+    Entity thirdLocation = new EntityBuilder()
         .environment(environment)
         .entityType("Room")
         .putPropertyMap("address", "Room 456, 789 Street, 012 Avenue")
@@ -186,7 +186,7 @@ public class PropertyNearbyConditionClientPerfTest {
             .useGeoHash(true)
             .build())
         .build();
-    DataFactoryEntities entities = entityStore.getEntities(entityQuery).get();
+    Entities entities = entityStore.getEntities(entityQuery).get();
     long time = System.currentTimeMillis() - start;
     LOG.info("Time to complete query (ms): " + time);
     assertNotNull(entities);

--- a/src/test/java/com/divroll/datafactory/conditions/PropertyNearbyConditionPerfTest.java
+++ b/src/test/java/com/divroll/datafactory/conditions/PropertyNearbyConditionPerfTest.java
@@ -23,9 +23,9 @@ import com.divroll.datafactory.DataFactory;
 import com.divroll.datafactory.GeoHash;
 import com.divroll.datafactory.GeoPoint;
 import com.divroll.datafactory.TestEnvironment;
-import com.divroll.datafactory.builders.DataFactoryEntities;
-import com.divroll.datafactory.builders.DataFactoryEntity;
-import com.divroll.datafactory.builders.DataFactoryEntityBuilder;
+import com.divroll.datafactory.builders.Entities;
+import com.divroll.datafactory.builders.Entity;
+import com.divroll.datafactory.builders.EntityBuilder;
 import com.divroll.datafactory.builders.queries.EntityQuery;
 import com.divroll.datafactory.builders.queries.EntityQueryBuilder;
 import com.divroll.datafactory.repositories.EntityStore;
@@ -56,20 +56,20 @@ public class PropertyNearbyConditionPerfTest {
     long start = System.currentTimeMillis();
 
     for (int i = 0; i < 999; i++) {
-      entityStore.saveEntity(new DataFactoryEntityBuilder()
+      entityStore.saveEntity(new EntityBuilder()
           .environment(environment)
           .entityType("Room")
           .putPropertyMap("geoLocation", new GeoPoint(120.954228, 14.301893))
           .build()).get();
     }
 
-    entityStore.saveEntity(new DataFactoryEntityBuilder()
+    entityStore.saveEntity(new EntityBuilder()
         .environment(environment)
         .entityType("Room")
         .putPropertyMap("geoLocation", new GeoPoint(120.976187, 14.581310))
         .build()).get();
 
-    DataFactoryEntities dataFactoryEntities =
+    Entities dataFactoryEntities =
         entityStore.getEntities(new EntityQueryBuilder()
             .environment(environment)
             .entityType("Room")
@@ -81,7 +81,7 @@ public class PropertyNearbyConditionPerfTest {
     long time = System.currentTimeMillis() - start;
     LOG.info("Time to save complete (ms): " + time);
     start = System.currentTimeMillis();
-    List<DataFactoryEntity> matched = new ArrayList<>();
+    List<Entity> matched = new ArrayList<>();
     List<Long> times = new ArrayList<>();
 
     boolean hasMore = true;
@@ -101,7 +101,7 @@ public class PropertyNearbyConditionPerfTest {
           .offset(offset)
           .max(max)
           .build();
-      DataFactoryEntities entities = entityStore.getEntities(entityQuery).get();
+      Entities entities = entityStore.getEntities(entityQuery).get();
       matched.addAll(entities.entities());
       time = System.currentTimeMillis() - start;
       times.add(time);
@@ -125,7 +125,7 @@ public class PropertyNearbyConditionPerfTest {
     String environment = TestEnvironment.getEnvironment();
     EntityStore entityStore = DataFactory.getInstance().getEntityStore();
 
-    DataFactoryEntity firstLocation = new DataFactoryEntityBuilder()
+    Entity firstLocation = new EntityBuilder()
         .environment(environment)
         .entityType("Room")
         .putPropertyMap("address", "Room 123, 456 Street, 789 Avenue")
@@ -134,7 +134,7 @@ public class PropertyNearbyConditionPerfTest {
     firstLocation = entityStore.saveEntity(firstLocation).get();
     assertNotNull(firstLocation.entityId());
     for(int i=0;i<10000;i++){
-      DataFactoryEntity secondLocation = new DataFactoryEntityBuilder()
+      Entity secondLocation = new EntityBuilder()
           .environment(environment)
           .entityType("Room")
           .putPropertyMap("address", "Room 456, 789 Street, 012 Avenue")
@@ -143,7 +143,7 @@ public class PropertyNearbyConditionPerfTest {
       secondLocation = entityStore.saveEntity(secondLocation).get();
       //assertNotNull(secondLocation.entityId());
     }
-    DataFactoryEntity thirdLocation = new DataFactoryEntityBuilder()
+    Entity thirdLocation = new EntityBuilder()
         .environment(environment)
         .entityType("Room")
         .putPropertyMap("address", "Room 456, 789 Street, 012 Avenue")
@@ -163,7 +163,7 @@ public class PropertyNearbyConditionPerfTest {
             .useGeoHash(true)
             .build())
         .build();
-    DataFactoryEntities entities = entityStore.getEntities(entityQuery).get();
+    Entities entities = entityStore.getEntities(entityQuery).get();
     long time = System.currentTimeMillis() - start;
     LOG.info("Time to complete query (ms): " + time);
     assertNotNull(entities);

--- a/src/test/java/com/divroll/datafactory/conditions/PropertyNearbyConditionTest.java
+++ b/src/test/java/com/divroll/datafactory/conditions/PropertyNearbyConditionTest.java
@@ -23,9 +23,9 @@ import com.divroll.datafactory.DataFactory;
 import com.divroll.datafactory.GeoHash;
 import com.divroll.datafactory.GeoPoint;
 import com.divroll.datafactory.TestEnvironment;
-import com.divroll.datafactory.builders.DataFactoryEntities;
-import com.divroll.datafactory.builders.DataFactoryEntity;
-import com.divroll.datafactory.builders.DataFactoryEntityBuilder;
+import com.divroll.datafactory.builders.Entities;
+import com.divroll.datafactory.builders.Entity;
+import com.divroll.datafactory.builders.EntityBuilder;
 import com.divroll.datafactory.builders.queries.EntityQuery;
 import com.divroll.datafactory.builders.queries.EntityQueryBuilder;
 import com.divroll.datafactory.repositories.EntityStore;
@@ -49,7 +49,7 @@ public class PropertyNearbyConditionTest {
   public void testNearbyCondition() throws Exception {
     String environment = TestEnvironment.getEnvironment();
     EntityStore entityStore = DataFactory.getInstance().getEntityStore();
-    DataFactoryEntity firstLocation = new DataFactoryEntityBuilder()
+    Entity firstLocation = new EntityBuilder()
         .environment(environment)
         .entityType("Room")
         .putPropertyMap("address", "Room 123, 456 Street, 789 Avenue")
@@ -57,7 +57,7 @@ public class PropertyNearbyConditionTest {
         .build();
     firstLocation = entityStore.saveEntity(firstLocation).get();
     assertNotNull(firstLocation.entityId());
-    DataFactoryEntity secondLocation = new DataFactoryEntityBuilder()
+    Entity secondLocation = new EntityBuilder()
         .environment(environment)
         .entityType("Room")
         .putPropertyMap("address", "Room 456, 789 Street, 012 Avenue")
@@ -65,7 +65,7 @@ public class PropertyNearbyConditionTest {
         .build();
     secondLocation = entityStore.saveEntity(secondLocation).get();
     assertNotNull(secondLocation.entityId());
-    DataFactoryEntity thirdLocation = new DataFactoryEntityBuilder()
+    Entity thirdLocation = new EntityBuilder()
         .environment(environment)
         .entityType("Room")
         .putPropertyMap("address", "Room 456, 789 Street, 012 Avenue")
@@ -84,7 +84,7 @@ public class PropertyNearbyConditionTest {
             .distance(100.0)
             .build())
         .build();
-    DataFactoryEntities entities = entityStore.getEntities(entityQuery).get();
+    Entities entities = entityStore.getEntities(entityQuery).get();
     long time = System.currentTimeMillis() - start;
     LOG.info("Time to complete (ms): " + time);
     assertNotNull(entities);
@@ -95,14 +95,14 @@ public class PropertyNearbyConditionTest {
   public void testNearbyConditionShouldBeZero() throws Exception {
     String environment = TestEnvironment.getEnvironment();
     EntityStore entityStore = DataFactory.getInstance().getEntityStore();
-    DataFactoryEntity dataFactoryEntity = new DataFactoryEntityBuilder()
+    Entity entity = new EntityBuilder()
         .environment(environment)
         .entityType("Room")
         .putPropertyMap("address", "Room 456, 789 Street, 012 Avenue")
         .putPropertyMap("geoLocation", new GeoPoint(120.984293, 14.535238))
         .build();
-    dataFactoryEntity = entityStore.saveEntity(dataFactoryEntity).get();
-    assertNotNull(dataFactoryEntity.entityId());
+    entity = entityStore.saveEntity(entity).get();
+    assertNotNull(entity.entityId());
     EntityQuery entityQuery = new EntityQueryBuilder()
         .environment(environment)
         .entityType("Room")
@@ -113,7 +113,7 @@ public class PropertyNearbyConditionTest {
             .distance(200.0)
             .build())
         .build();
-    DataFactoryEntities entities = entityStore.getEntities(entityQuery).get();
+    Entities entities = entityStore.getEntities(entityQuery).get();
     assertNotNull(entities);
     assertEquals(0, entities.entities().size());
   }
@@ -122,7 +122,7 @@ public class PropertyNearbyConditionTest {
   public void testNearbyConditionUseGeoHash() throws Exception {
     String environment = TestEnvironment.getEnvironment();
     EntityStore entityStore = DataFactory.getInstance().getEntityStore();
-    DataFactoryEntity firstLocation = new DataFactoryEntityBuilder()
+    Entity firstLocation = new EntityBuilder()
         .environment(environment)
         .entityType("Room")
         .putPropertyMap("address", "Room 123, 456 Street, 789 Avenue")
@@ -130,7 +130,7 @@ public class PropertyNearbyConditionTest {
         .build();
     firstLocation = entityStore.saveEntity(firstLocation).get();
     assertNotNull(firstLocation.entityId());
-    DataFactoryEntity secondLocation = new DataFactoryEntityBuilder()
+    Entity secondLocation = new EntityBuilder()
         .environment(environment)
         .entityType("Room")
         .putPropertyMap("address", "Room 456, 789 Street, 012 Avenue")
@@ -138,7 +138,7 @@ public class PropertyNearbyConditionTest {
         .build();
     secondLocation = entityStore.saveEntity(secondLocation).get();
     assertNotNull(secondLocation.entityId());
-    DataFactoryEntity thirdLocation = new DataFactoryEntityBuilder()
+    Entity thirdLocation = new EntityBuilder()
         .environment(environment)
         .entityType("Room")
         .putPropertyMap("address", "Room 456, 789 Street, 012 Avenue")
@@ -158,7 +158,7 @@ public class PropertyNearbyConditionTest {
             .useGeoHash(true)
             .build())
         .build();
-    DataFactoryEntities entities = entityStore.getEntities(entityQuery).get();
+    Entities entities = entityStore.getEntities(entityQuery).get();
     long time = System.currentTimeMillis() - start;
     LOG.info("Time to complete (ms): " + time);
     assertNotNull(entities);
@@ -169,14 +169,14 @@ public class PropertyNearbyConditionTest {
   public void testNearbyConditionUseGeoHashShouldBeZero() throws Exception {
     String environment = TestEnvironment.getEnvironment();
     EntityStore entityStore = DataFactory.getInstance().getEntityStore();
-    DataFactoryEntity dataFactoryEntity = new DataFactoryEntityBuilder()
+    Entity entity = new EntityBuilder()
         .environment(environment)
         .entityType("Room")
         .putPropertyMap("address", "Room 456, 789 Street, 012 Avenue")
         .putPropertyMap("geoLocation", new GeoHash(120.984293, 14.535238).toString())
         .build();
-    dataFactoryEntity = entityStore.saveEntity(dataFactoryEntity).get();
-    assertNotNull(dataFactoryEntity.entityId());
+    entity = entityStore.saveEntity(entity).get();
+    assertNotNull(entity.entityId());
     EntityQuery entityQuery = new EntityQueryBuilder()
         .environment(environment)
         .entityType("Room")
@@ -188,7 +188,7 @@ public class PropertyNearbyConditionTest {
             .useGeoHash(true)
             .build())
         .build();
-    DataFactoryEntities entities = entityStore.getEntities(entityQuery).get();
+    Entities entities = entityStore.getEntities(entityQuery).get();
     assertNotNull(entities);
     assertEquals(0, entities.entities().size());
   }

--- a/src/test/java/com/divroll/datafactory/repositories/EntityStoreTest.java
+++ b/src/test/java/com/divroll/datafactory/repositories/EntityStoreTest.java
@@ -25,9 +25,9 @@ import com.divroll.datafactory.actions.ImmutableBlobRemoveAction;
 import com.divroll.datafactory.actions.ImmutableBlobRenameAction;
 import com.divroll.datafactory.actions.ImmutableBlobRenameRegexAction;
 import com.divroll.datafactory.actions.ImmutableLinkAction;
-import com.divroll.datafactory.builders.DataFactoryBlobBuilder;
-import com.divroll.datafactory.builders.DataFactoryEntity;
-import com.divroll.datafactory.builders.DataFactoryEntityBuilder;
+import com.divroll.datafactory.builders.BlobBuilder;
+import com.divroll.datafactory.builders.Entity;
+import com.divroll.datafactory.builders.EntityBuilder;
 import com.divroll.datafactory.builders.queries.BlobQueryBuilder;
 import com.divroll.datafactory.builders.queries.EntityQuery;
 import com.divroll.datafactory.builders.queries.EntityQueryBuilder;
@@ -61,13 +61,13 @@ public class EntityStoreTest {
     String environment = TestEnvironment.getEnvironment();
     EntityStore entityStore = DataFactory.getInstance().getEntityStore();
     assertNotNull(entityStore);
-    DataFactoryEntity dataFactoryEntity = entityStore.saveEntity(new DataFactoryEntityBuilder()
+    Entity entity = entityStore.saveEntity(new EntityBuilder()
         .environment(environment)
         .entityType("Foo")
         .putPropertyMap("foo", "bar")
         .build()).get();
-    assertNotNull(dataFactoryEntity);
-    assertNotNull(dataFactoryEntity.entityId());
+    assertNotNull(entity);
+    assertNotNull(entity.entityId());
   }
 
   @Test
@@ -76,22 +76,22 @@ public class EntityStoreTest {
     EntityStore entityStore = DataFactory.getInstance().getEntityStore();
     assertNotNull(entityStore);
     // Create with blob
-    DataFactoryEntity dataFactoryEntity = entityStore.saveEntity(new DataFactoryEntityBuilder()
+    Entity entity = entityStore.saveEntity(new EntityBuilder()
         .environment(environment)
         .entityType("Foo")
         .putPropertyMap("foo", "bar")
-        .addBlobs(new DataFactoryBlobBuilder()
+        .addBlobs(new BlobBuilder()
             .blobName("message")
             .blobStream(
                 new SimpleRemoteInputStream(ByteSource.wrap("Hello Word".getBytes()).openStream()))
             .build())
         .build()).get();
-    assertNotNull(dataFactoryEntity);
-    assertNotNull(dataFactoryEntity.entityId());
+    assertNotNull(entity);
+    assertNotNull(entity.entityId());
     // Get with blob
     entityStore.getEntity(new EntityQueryBuilder()
         .environment(environment)
-        .entityId(dataFactoryEntity.entityId())
+        .entityId(entity.entityId())
         .addBlobQueries(new BlobQueryBuilder()
             .blobName("message")
             .include(true)
@@ -115,10 +115,10 @@ public class EntityStoreTest {
       });
     });
     // Delete blob
-    entityStore.saveEntity(new DataFactoryEntityBuilder()
+    entityStore.saveEntity(new EntityBuilder()
         .environment(environment)
         .entityType("Foo")
-        .entityId(dataFactoryEntity.entityId())
+        .entityId(entity.entityId())
         .addActions(ImmutableBlobRemoveAction.builder()
             .blobNames(Arrays.asList("message"))
             .build())
@@ -126,7 +126,7 @@ public class EntityStoreTest {
     // Get with blob, expecting blob is removed
     entityStore.getEntity(new EntityQueryBuilder()
         .environment(environment)
-        .entityId(dataFactoryEntity.entityId())
+        .entityId(entity.entityId())
         .addBlobQueries(new BlobQueryBuilder()
             .blobName("message")
             .include(true)
@@ -144,11 +144,11 @@ public class EntityStoreTest {
     EntityStore entityStore = DataFactory.getInstance().getEntityStore();
     assertNotNull(entityStore);
     // Create with blob
-    DataFactoryEntity dataFactoryEntity = entityStore.saveEntity(new DataFactoryEntityBuilder()
+    Entity dataFactoryEntity = entityStore.saveEntity(new EntityBuilder()
         .environment(environment)
         .entityType("Foo")
         .putPropertyMap("foo", "bar")
-        .addBlobs(new DataFactoryBlobBuilder()
+        .addBlobs(new BlobBuilder()
             .blobName("message")
             .blobStream(
                 new SimpleRemoteInputStream(ByteSource.wrap("Hello Word".getBytes()).openStream()))
@@ -183,7 +183,7 @@ public class EntityStoreTest {
       });
     });
     // Rename blob
-    DataFactoryEntity entity = new DataFactoryEntityBuilder()
+    Entity entity = new EntityBuilder()
         .environment(environment)
         .entityType("Foo")
         .entityId(dataFactoryEntity.entityId())
@@ -224,16 +224,16 @@ public class EntityStoreTest {
     EntityStore entityStore = DataFactory.getInstance().getEntityStore();
     assertNotNull(entityStore);
     // Create with blob
-    DataFactoryEntity dataFactoryEntity = entityStore.saveEntity(new DataFactoryEntityBuilder()
+    Entity dataFactoryEntity = entityStore.saveEntity(new EntityBuilder()
         .environment(environment)
         .entityType("Foo")
         .putPropertyMap("foo", "bar")
-        .addBlobs(new DataFactoryBlobBuilder()
+        .addBlobs(new BlobBuilder()
             .blobName("message")
             .blobStream(
                 new SimpleRemoteInputStream(ByteSource.wrap("Should not be replaced".getBytes()).openStream()))
             .build())
-        .addBlobs(new DataFactoryBlobBuilder()
+        .addBlobs(new BlobBuilder()
             .blobName("123")
             .blobStream(
                 new SimpleRemoteInputStream(ByteSource.wrap("Should be replaced".getBytes()).openStream()))
@@ -242,7 +242,7 @@ public class EntityStoreTest {
     assertNotNull(dataFactoryEntity);
     assertNotNull(dataFactoryEntity.entityId());
     // Rename blob with regex
-    DataFactoryEntity entity = new DataFactoryEntityBuilder()
+    Entity entity = new EntityBuilder()
         .environment(environment)
         .entityType("Foo")
         .entityId(dataFactoryEntity.entityId())
@@ -376,17 +376,17 @@ public class EntityStoreTest {
     String environment = TestEnvironment.getEnvironment();
     EntityStore entityStore = DataFactory.getInstance().getEntityStore();
     assertNotNull(entityStore);
-    DataFactoryEntity dataFactoryEntity = entityStore.saveEntity(new DataFactoryEntityBuilder()
+    Entity entity = entityStore.saveEntity(new EntityBuilder()
         .environment(environment)
         .entityType("Foo")
         .putPropertyMap("foo", "fooBar")
         .build()).get();
-    assertNotNull(dataFactoryEntity);
-    assertNotNull(dataFactoryEntity.entityId());
+    assertNotNull(entity);
+    assertNotNull(entity.entityId());
 
-    dataFactoryEntity = entityStore.saveEntity(new DataFactoryEntityBuilder()
+    entity = entityStore.saveEntity(new EntityBuilder()
         .environment(environment)
-        .entityId(dataFactoryEntity.entityId())
+        .entityId(entity.entityId())
         .putPropertyMap("hasFooBaz", true)
         .addConditions(new PropertyStartsWithConditionBuilder()
             .propertyName("foo")
@@ -400,27 +400,27 @@ public class EntityStoreTest {
     String environment = TestEnvironment.getEnvironment();
     EntityStore entityStore = DataFactory.getInstance().getEntityStore();
     assertNotNull(entityStore);
-    DataFactoryEntity dataFactoryEntity = entityStore.saveEntity(new DataFactoryEntityBuilder()
+    Entity entity = entityStore.saveEntity(new EntityBuilder()
         .environment(environment)
         .entityType("Foo")
         .putPropertyMap("foo", "fooBar")
         .build()).get();
-    assertNotNull(dataFactoryEntity);
-    assertNotNull(dataFactoryEntity.entityId());
+    assertNotNull(entity);
+    assertNotNull(entity.entityId());
     // Update entity if property "starts with", else fail
-    String entityId = dataFactoryEntity.entityId();
-    dataFactoryEntity = entityStore.saveEntity(new DataFactoryEntityBuilder()
+    String entityId = entity.entityId();
+    entity = entityStore.saveEntity(new EntityBuilder()
         .environment(environment)
-        .entityId(dataFactoryEntity.entityId())
+        .entityId(entity.entityId())
         .putPropertyMap("hasFooBar", true)
         .addConditions(new PropertyStartsWithConditionBuilder()
             .propertyName("foo")
             .startsWith("fooBar")
             .build())
         .build()).get();
-    assertNotNull(dataFactoryEntity);
-    assertNotNull(dataFactoryEntity.entityId());
-    assertEquals(entityId, dataFactoryEntity.entityId());
+    assertNotNull(entity);
+    assertNotNull(entity.entityId());
+    assertEquals(entityId, entity.entityId());
     // Get entity
     EntityQuery entityQuery = new EntityQueryBuilder()
         .environment(environment)
@@ -437,21 +437,21 @@ public class EntityStoreTest {
     String environment = TestEnvironment.getEnvironment();
     EntityStore entityStore = DataFactory.getInstance().getEntityStore();
     assertNotNull(entityStore);
-    DataFactoryEntity dataFactoryEntity = entityStore.saveEntity(new DataFactoryEntityBuilder()
+    Entity entity = entityStore.saveEntity(new EntityBuilder()
         .environment(environment)
         .entityType("Foo")
         .putPropertyMap("foo", "bar")
         .build()).get();
-    assertNotNull(dataFactoryEntity);
-    assertNotNull(dataFactoryEntity.entityId());
+    assertNotNull(entity);
+    assertNotNull(entity.entityId());
     EntityQuery query = new EntityQueryBuilder()
         .environment(environment)
-        .entityId(dataFactoryEntity.entityId())
+        .entityId(entity.entityId())
         .build();
-    DataFactoryEntity savedEntity = entityStore.getEntity(query).get();
+    Entity savedEntity = entityStore.getEntity(query).get();
     assertNotNull(savedEntity);
-    assertEquals(dataFactoryEntity.entityId(), savedEntity.entityId());
-    assertEquals(dataFactoryEntity.propertyMap().get("foo"), savedEntity.propertyMap().get("foo"));
+    assertEquals(entity.entityId(), savedEntity.entityId());
+    assertEquals(entity.propertyMap().get("foo"), savedEntity.propertyMap().get("foo"));
   }
 
   @Test(expected = EntityRemovedInDatabaseException.class)
@@ -459,7 +459,7 @@ public class EntityStoreTest {
     String environment = TestEnvironment.getEnvironment();
     EntityStore entityStore = DataFactory.getInstance().getEntityStore();
     assertNotNull(entityStore);
-    DataFactoryEntity dataFactoryEntity = entityStore.saveEntity(new DataFactoryEntityBuilder()
+    Entity entity = entityStore.saveEntity(new EntityBuilder()
         .environment(environment)
         .entityType("Foo")
         .putPropertyMap("foo", "bar")
@@ -469,6 +469,6 @@ public class EntityStoreTest {
             .isSet(true)
             .build())
         .build()).get();
-    assertNotNull(dataFactoryEntity);
+    assertNotNull(entity);
   }
 }


### PR DESCRIPTION
Renamed `DataFactoryBlob` to `Blob`, `DataFactoryEntities` to `Entities`, `DataFactoryEntity` to `Entity`, `DataFactoryEntityType` to `EntityType`, `DataFactoryEntityTypes` to `EntityTypes`, `DataFactoryProperty` to `Property`. This change makes class names more straightforward and succinct.